### PR TITLE
Respond to /_matrix/client/versions

### DIFF
--- a/src/github.com/matrix-org/dendron/dendron/main.go
+++ b/src/github.com/matrix-org/dendron/dendron/main.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/matrix-org/dendron/login"
 	"github.com/matrix-org/dendron/proxy"
+	"github.com/matrix-org/dendron/versions"
 
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -102,13 +103,20 @@ func main() {
 		panic(err)
 	}
 
+	versionsHandler, err := versions.NewHandler(&synapseProxy, time.Hour)
+	if err != nil {
+		panic(err)
+	}
+
 	loginFunc := prometheus.InstrumentHandler("login", loginHandler)
 	proxyFunc := prometheus.InstrumentHandler("proxy", &synapseProxy)
+	versionsFunc := prometheus.InstrumentHandler("versions", versionsHandler)
 
 	mux := http.NewServeMux()
 	mux.Handle("/", proxyFunc)
 	mux.Handle("/_matrix/client/api/v1/login", loginFunc)
 	mux.Handle("/_matrix/client/r0/login", loginFunc)
+	mux.Handle("/_matrix/client/versions", versionsFunc)
 	mux.HandleFunc("/_dendron/test", func(w http.ResponseWriter, req *http.Request) {
 		fmt.Fprintln(w, "test")
 	})

--- a/src/github.com/matrix-org/dendron/versions/versions.go
+++ b/src/github.com/matrix-org/dendron/versions/versions.go
@@ -1,0 +1,65 @@
+package versions
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"sync/atomic"
+	"time"
+
+	"github.com/matrix-org/dendron/proxy"
+)
+
+// NewHandler creates an http.Handler which serves up the client-server API versions currently served by the delegated Synapse.
+// It caches this response for updateInterval, and will serve stale cache entries if it cannot get a new value from the Synapse.
+func NewHandler(p *proxy.SynapseProxy, updateInterval time.Duration) (*handler, error) {
+	h := &handler{p: p}
+	if err := h.update(); err != nil {
+		return nil, fmt.Errorf("error getting initial version: %v", err)
+	}
+
+	go func() {
+		for {
+			select {
+			case <-time.After(updateInterval):
+				h.update()
+			}
+		}
+	}()
+
+	return h, nil
+}
+
+type handler struct {
+	p *proxy.SynapseProxy
+
+	resp atomic.Value // Always contains a valid []byte
+}
+
+func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	proxy.SetHeaders(w)
+	w.Write(h.resp.Load().([]byte))
+}
+
+func (h *handler) update() error {
+	resp, err := h.p.Client.Get(h.p.URL.String() + "/_matrix/client/versions")
+	if err != nil {
+		log.Printf("Error updating /version: %v", err)
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		respBytes, _ := httputil.DumpResponse(resp, true)
+		err := fmt.Errorf("error updating /version: status code: %v, response: %v", resp.StatusCode, string(respBytes))
+		log.Print(err)
+		return err
+	}
+	bytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	h.resp.Store(bytes)
+	return nil
+}

--- a/src/github.com/matrix-org/dendron/versions/versions_test.go
+++ b/src/github.com/matrix-org/dendron/versions/versions_test.go
@@ -1,0 +1,64 @@
+package versions
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/matrix-org/dendron/proxy"
+)
+
+type StaticHandler struct {
+	firstResponse  []byte
+	secondResponse []byte
+	requests       int32
+}
+
+func (s *StaticHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req := atomic.AddInt32(&s.requests, 1); req == 1 {
+		w.Write(s.firstResponse)
+	} else if req == 2 {
+		w.Write(s.secondResponse)
+	} else {
+		w.WriteHeader(500)
+		w.Write([]byte("ISE! ISE!"))
+	}
+}
+
+func TestVersions(t *testing.T) {
+	mockHandler := &StaticHandler{
+		firstResponse:  []byte("foo"),
+		secondResponse: []byte("bar"),
+	}
+	s := httptest.NewServer(mockHandler)
+	defer s.Close()
+
+	u, _ := url.Parse(s.URL)
+	p := &proxy.SynapseProxy{
+		URL:    *u,
+		Client: http.Client{},
+	}
+	h, err := NewHandler(p, 25*time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if val := h.resp.Load(); !reflect.DeepEqual(val, mockHandler.firstResponse) {
+		t.Fatalf("first response: want %q got %q", string(mockHandler.firstResponse), string(val.([]byte)))
+	}
+
+	sleepAndWantSecond := func(prefix string) {
+		time.Sleep(40 * time.Millisecond)
+		if val := h.resp.Load(); !reflect.DeepEqual(val, mockHandler.secondResponse) {
+			t.Fatalf("%s: want %q got %q", prefix, string(mockHandler.secondResponse), string(val.([]byte)))
+		}
+	}
+
+	sleepAndWantSecond("second response")
+	sleepAndWantSecond("after 500")
+	s.Close()
+	sleepAndWantSecond("after ECONNREFUSED")
+}


### PR DESCRIPTION
Polls the synapse every hour, and serves a cached response.
