### PR TITLE
Canonicalise the userID if the capitalisation is different

### DIFF
--- a/src/github.com/matrix-org/dendron/login/database.go
+++ b/src/github.com/matrix-org/dendron/login/database.go
@@ -26,7 +26,7 @@ func makeSQLDatabase(db *sql.DB) (database, error) {
 		return nil, err
 	}
 
-	log.Printf("Intitial minimum token ids are %d and %d")
+	log.Printf("Intitial minimum token ids are %d and %d", accessTokenID, refreshTokenID)
 
 	return &sqlDatabase{db, accessTokenID, refreshTokenID}, nil
 }

--- a/src/github.com/matrix-org/dendron/login/login.go
+++ b/src/github.com/matrix-org/dendron/login/login.go
@@ -105,7 +105,7 @@ func (h *MatrixLoginHandler) loginPassword(userID string, password string) (*mat
 		userID = "@" + userID + ":" + h.serverName
 	}
 
-	hash, err := h.db.passwordHash(userID)
+	canonicalID, hash, err := h.db.passwordHash(userID)
 	if err != nil {
 		return nil, &proxy.HTTPError{err, 403, "M_FORBIDDEN", "Forbidden"}
 	}
@@ -119,7 +119,7 @@ func (h *MatrixLoginHandler) loginPassword(userID string, password string) (*mat
 		return nil, &proxy.HTTPError{err, 500, "M_UNKNOWN", "Error generating login"}
 	}
 
-	response, err := h.makeLoginResponse(userID, expires, nonce)
+	response, err := h.makeLoginResponse(canonicalID, expires, nonce)
 	if err != nil {
 		return nil, &proxy.HTTPError{err, 500, "M_UNKNOWN", "Error generating login"}
 	}


### PR DESCRIPTION
Use the userID in the database instead.
