### PR TITLE
Make sure that the child processes shutdown.

### DIFF
--- a/src/github.com/matrix-org/dendron/dendron/main.go
+++ b/src/github.com/matrix-org/dendron/dendron/main.go
@@ -134,7 +134,7 @@ func main() {
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
 		s := <-signals
-		terminate <- fmt.Sprint("Got signal", s)
+		terminate <- fmt.Sprintf("Got signal %v", s)
 	}()
 
 	if *startSynapse {

--- a/src/github.com/matrix-org/dendron/dendron/main.go
+++ b/src/github.com/matrix-org/dendron/dendron/main.go
@@ -128,9 +128,9 @@ func main() {
 	var synapseLog = log.WithField("synapse", synapseURL.String())
 
 	// Used to terminate dendron.
-	terminate := make(chan string)
+	terminate := make(chan string, 1)
 
-	signals := make(chan os.Signal)
+	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		s := <-signals

--- a/src/github.com/matrix-org/dendron/dendron/main.go
+++ b/src/github.com/matrix-org/dendron/dendron/main.go
@@ -145,11 +145,13 @@ func main() {
 		synapse.Start()
 		defer synapse.Process.Signal(os.Interrupt)
 
+		// Wait for synapse to start.
 		if err := waitForSynapse(synapseURL, synapseLog); err != nil {
 			synapseLog.Panic(err)
 		}
 
 		go func() {
+			// Wait for synapse to stop.
 			synapse.Process.Wait()
 			terminate <- "Synapse Stopped"
 		}()
@@ -162,6 +164,7 @@ func main() {
 			defer pusher.Process.Signal(os.Interrupt)
 
 			go func() {
+				// Wait for the pusher to stop.
 				pusher.Process.Wait()
 				terminate <- "Pusher Stopped"
 			}()
@@ -174,10 +177,12 @@ func main() {
 			synchrotron.Start()
 			defer synchrotron.Process.Signal(os.Interrupt)
 
+			// Wait for the synchrotron to start.
 			if err := waitForSynapse(synchrotronURL, synapseLog); err != nil {
 				synapseLog.Panic(err)
 			}
 			go func() {
+				// Wait for the synchrotron to stop.
 				synchrotron.Process.Wait()
 				terminate <- "Synchrotron Stopped"
 			}()

--- a/src/github.com/matrix-org/dendron/dendron/main.go
+++ b/src/github.com/matrix-org/dendron/dendron/main.go
@@ -131,7 +131,7 @@ func main() {
 	terminate := make(chan string, 1)
 
 	signals := make(chan os.Signal, 1)
-	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(signals, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	go func() {
 		s := <-signals
 		terminate <- fmt.Sprint("Got signal", s)


### PR DESCRIPTION
Use `defer` to ensure that the child processes get told to shutdown.
Ensure that dendron will call the deferred cleanup functions when it
receives signals like SIGINT and SIGTERM by handling those signals and
cleanly exiting `main` when they occur.
Also shutdown dendron if any of the child processes terminate.
